### PR TITLE
Storable dclone v2

### DIFF
--- a/lib/Type/Tie.pm
+++ b/lib/Type/Tie.pm
@@ -146,7 +146,7 @@ BEGIN
 
 		my $type = $TYPE{$self};
 		my $refaddr = Scalar::Util::refaddr($type);
-		$tmp_clone_types{$refaddr} //= [ $type, 0 ];
+		$tmp_clone_types{$refaddr} ||= [ $type, 0 ];
 		++$tmp_clone_types{$refaddr}[1];
 		return (pack('j', $refaddr), $self);
 	}

--- a/lib/Type/Tie.pm
+++ b/lib/Type/Tie.pm
@@ -128,6 +128,45 @@ BEGIN
 		
 		wantarray ? @vals : $vals[0];
 	}
+
+	# store the $type for the exiting instances so the type can be set
+	# (uncloned) in the clone too. A clone process could be cloning several
+	# instances of this class, so use a hash to hold the types during
+	# cloning. These types are reference counted, so the last reference to
+	# a particular type deletes its key.
+	my %tmp_clone_types;
+	sub STORABLE_freeze {
+		die "Scalar::Util is needed for cloning with Storage::dclone"
+			unless eval { require Scalar::Util };
+		my $self = shift;
+		my $cloning = shift;
+
+		die "Storage::freeze only supported for dclone-ing"
+			unless $cloning;
+
+		my $type = $TYPE{$self};
+		my $refaddr = Scalar::Util::refaddr($type);
+		$tmp_clone_types{$refaddr} //= [ $type, 0 ];
+		++$tmp_clone_types{$refaddr}[1];
+		return (pack('j', $refaddr), $self);
+	}
+
+	sub STORABLE_thaw {
+		my $self = shift;
+		my $cloning = shift;
+		my $packedRefaddr = shift;
+		my $obj = shift;
+
+		die "Storage::thaw only supported for dclone-ing"
+			unless $cloning;
+
+		$self->_STORABLE_thaw_update_from_obj($obj);
+		my $refaddr = unpack('j', $packedRefaddr);
+		my $type = $tmp_clone_types{$refaddr}[0];
+		--$tmp_clone_types{$refaddr}[1]
+			or delete $tmp_clone_types{$refaddr};
+		$self->_set_type($type);
+	}
 };
 
 BEGIN
@@ -169,6 +208,12 @@ BEGIN
 		my ($start, $len, @rest) = @_;
 		$self->SUPER::SPLICE($start, $len, $self->coerce_and_check_value(@rest) );
 	}
+
+	sub _STORABLE_thaw_update_from_obj {
+		my $self = shift;
+		my $obj = shift;
+		@$self = @$obj;
+	}
 };
 
 BEGIN
@@ -191,6 +236,12 @@ BEGIN
 		my $self = shift;
 		$self->SUPER::STORE($_[0], $self->coerce_and_check_value($_[1]));
 	}
+
+	sub _STORABLE_thaw_update_from_obj {
+		my $self = shift;
+		my $obj = shift;
+		%$self = %$obj;
+	}
 };
 
 BEGIN
@@ -212,6 +263,12 @@ BEGIN
 	{
 		my $self = shift;
 		$self->SUPER::STORE( $self->coerce_and_check_value($_[0]) );
+	}
+
+	sub _STORABLE_thaw_update_from_obj {
+		my $self = shift;
+		my $obj = shift;
+		$self = $obj;
 	}
 };
 
@@ -310,6 +367,12 @@ L<Type::Tiny|Type::Tiny::Manual>
 =item ttie
 
 =end trustme
+
+=head2 About Cloning with Storage::dclone (and Clone::clone)
+
+Cloning variables with Storage::dclone works, but cloning with Clone::clone is
+not possible. See
+L<Bug #127576 for Type-Tie: Doesn't work with Clone::clone|https://rt.cpan.org/Public/Bug/Display.html?id=127576>
 
 =head1 BUGS
 

--- a/t/06storable.t
+++ b/t/06storable.t
@@ -1,0 +1,86 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Test that Type::Tie works with Storable::dclone
+
+=head1 AUTHOR
+
+Toby Inkster E<lt>tobyink@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2013-2014 by Toby Inkster.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+
+=cut
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Requires 'Types::Standard', 'Scalar::Util', 'Storable';
+use Test::Fatal;
+
+use Type::Tie;
+
+use Types::Standard qw( Int );
+use Storable qw(dclone);
+
+# Hashes
+
+ttie my %hash, Int;
+
+my $ref = \%hash;
+my $hashDclone = dclone(\%hash);
+
+eval {
+	$hashDclone->{a} = 1;
+};
+ok(! $@);
+
+eval {
+	$hashDclone->{a} = 'a';
+};
+ok($@);
+
+# Arrays
+
+ttie my @array, Int;
+
+my $arrayDclone = dclone(\@array);
+
+eval {
+	push @$arrayDclone, 1;
+};
+ok(! $@);
+
+eval {
+	push @$arrayDclone, 'a';
+};
+ok($@);
+
+# Scalar
+
+my $scalarContainer = [ '' ];
+
+ttie $scalarContainer->[0], Int;
+
+my $scalarContainerDclone = dclone(\@array);
+
+eval {
+	$scalarContainerDclone->[0] = 1;
+};
+ok(! $@);
+
+eval {
+	$scalarContainerDclone->[0] = 'a';
+};
+ok($@);
+
+done_testing();


### PR DESCRIPTION
Set up Storable hooks to play nice with Storable::dclone

And document that Clone::clone will not work

See: Bug #127576 for Type-Tie: Doesn't work with Clone::clone
https://rt.cpan.org/Public/Bug/Display.html?id=127576

This is a second attempt at a pull request. I abandoned and closed the first pull-request ( #1 ) after a couple of false starts.

I personally think it is a sound approach and perhaps the best that can be done for Storage::dclone, but perhaps also also a little much code to support this corner case in a relatively small module. Do you have any thoughts on that, @tobyink ?