### PR TITLE
Proposed fix for pod error reported by CPANTS.

### DIFF
--- a/lib/Type/Tie.pm
+++ b/lib/Type/Tie.pm
@@ -307,7 +307,7 @@ L<Type::Tiny|Type::Tiny::Manual>
 
 =begin trustme
 
-=item ttie
+      ttie
 
 =end trustme
 


### PR DESCRIPTION
Hi @tobyink 

Please review the PR.

CPANTS says:

       Error: *** ERROR: '=item' outside of any '=over' at line 310 in file Type-Tie-0.014/lib/Type/Tie.pm *** 
       ERROR: =end trustme without matching =begin. (Stack: =begin trustme; =over) at line 312 in file 
       Type-Tie-0.014/lib/Type/Tie.pm *** ERROR: You forgot a '=back' before '=head1' at line 314 in file 
       Type-Tie-0.014/lib/Type/Tie.pm *** ERROR: =begin trustme without matching =end trustme at line 
       308 in file Type-Tie-0.014/lib/Type/Tie.pm

Hopefully, the changes will stop CPANTS complaining.

Many Thanks.
Best Regards,
Mohammad S Anwar